### PR TITLE
Fix: Left-align text and improve wrapping in table cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -521,8 +521,10 @@ footer .footer-copyright-link:hover {
     flex-shrink: 0; 
 }
 .table-card-grid .card p span {
-    text-align: right; 
+    text-align: left; /* Changed from right to left */
     color: var(--primary-text);
+    flex-grow: 1; /* Added */
+    word-break: break-word; /* Added */
 }
 
 /* Enhanced List Styling */


### PR DESCRIPTION
I modified style.css to address layout issues in card-based tables (affecting Tables 3, 4, 5, and 6 which use the .table-card-grid class):

- Changed text alignment for values in key-value pairs to left:
  - In `.table-card-grid .card p span`, changed `text-align` from `right` to `left`.
- Improved text handling and space utilization:
  - Added `flex-grow: 1` to `.table-card-grid .card p span` to allow values to take available space.
  - Added `word-break: break-word` to `.table-card-grid .card p span` to prevent long strings from breaking the layout.

These changes ensure all text within the table cards is left-aligned and that content fits more reliably within card boundaries.