### PR TITLE
Fix: Update Vanta.js library paths to use CDN URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -896,8 +896,8 @@
     </footer>
 
     <script src="script.js"></script>
-    <script src="p5.min.js"></script>
-    <script src="vanta.topology.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vanta/0.5.24/vanta.topology.min.js"></script>
     <script>
     VANTA.TOPOLOGY({
       el: "#your-element-selector", // Target the hero section


### PR DESCRIPTION
I modified index.html to load P5.js and Vanta.js libraries from CDNJS CDN URLs instead of local paths.

This change aims to resolve issues where the Vanta.js animated background might not have been working due to the browser's inability to find the library files at the previously specified local paths. Using CDNs ensures more reliable loading of these dependencies.