### PR TITLE
refactor: Revert header transparency, keep centered logo

### DIFF
--- a/style.css
+++ b/style.css
@@ -149,7 +149,7 @@ header {
     left: 0;
     width: 100%;
     height: var(--nav-height-universal); 
-    background-color: rgba(10, 25, 47, 0.3825); 
+    background-color: rgba(10, 25, 47, 0.85); 
     backdrop-filter: blur(10px); 
     z-index: 1060; 
     padding: 0 20px; 


### PR DESCRIPTION
Reverts the header background transparency to its original state (alpha 0.85).

The following changes from the previous commit remain:
- A floating "scroll-to-top" arrow button in the bottom-right.
- The main header logo is centered.

This commit addresses your feedback to undo the transparency adjustment while retaining other UI enhancements.