### PR TITLE
fix: Remove main element top padding for direct content alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -352,7 +352,6 @@ header .logo a:hover {
 
 /* Main Content Sections - Increased whitespace */
 main {
-    padding-top: var(--nav-height-universal); 
 }
 
 section {


### PR DESCRIPTION
Removes the `padding-top` from the `main` HTML element. The first content section (`#your-element-selector`) already possesses its own top padding, which will now correctly manage the spacing below the fixed header.

This change ensures that the main content area aligns directly under the header without redundant padding, relying on individual sections for their specific spacing needs.