### PR TITLE
fix: Ensure consistent top padding for hero section

### DIFF
--- a/style.css
+++ b/style.css
@@ -686,7 +686,10 @@ footer .footer-copyright-link:hover {
         padding: 100px 30px; 
     }
     #your-element-selector { 
-      padding: 40px 20px; 
+      padding-top: var(--nav-height-universal);
+      padding-right: 20px;
+      padding-bottom: 40px; 
+      padding-left: 20px;
       min-height: calc(100vh - var(--nav-height-universal));
     }
 
@@ -723,7 +726,10 @@ footer .footer-copyright-link:hover {
         padding: 80px 20px; 
     }
      #your-element-selector { 
-      padding: 30px 15px; 
+      padding-top: var(--nav-height-universal);
+      padding-right: 15px;
+      padding-bottom: 30px;
+      padding-left: 15px;
     }
 
     header .logo a {


### PR DESCRIPTION
Adjusts the top padding of the hero section (`#your-element-selector`) to be `var(--nav-height-universal)` (60px) across all screen sizes. This change prevents the fixed header from overlapping the content of the hero section on smaller screens.

The bottom, left, and right padding values for this section in mobile and tablet views have been preserved from their previous settings.