### PR TITLE
Fix: Remove padding-top from main section in specific media queries

### DIFF
--- a/style.css
+++ b/style.css
@@ -647,7 +647,6 @@ footer .footer-copyright-link:hover {
         height: var(--nav-height-universal); 
     }
     main {
-        padding-top: var(--nav-height-universal);
     }
      .mobile-menu {
         padding-top: calc(var(--nav-height-universal) + 25px);
@@ -672,7 +671,6 @@ footer .footer-copyright-link:hover {
         display: flex; 
     }
     main {
-        padding-top: var(--nav-height-universal);
     }
 
     h1 { font-size: 2.2rem; }


### PR DESCRIPTION
This commit removes the `padding-top: var(--nav-height-universal);` rule from the `main` selector within the `@media (max-width: 992px)` and `@media (max-width: 768px)` media queries in `style.css` as you requested in the issue.